### PR TITLE
Add support for NewType, typing.List, typing.Dict type hinting

### DIFF
--- a/dataenforce/__init__.py
+++ b/dataenforce/__init__.py
@@ -61,6 +61,8 @@ def _get_columns_dtypes(p):
         stop_type = p.stop
         if isinstance(stop_type, NewType):
             stop_type = stop_type.__supertype__
+        if hasattr(stop_type, "__origin__"):
+            stop_type = stop_type.__origin__
         if not inspect.isclass(stop_type):
             raise TypeError("Column type hints must be classes or of type NewType, error with %s" % repr(stop_type))
         dtypes[p.start] = stop_type

--- a/dataenforce/__init__.py
+++ b/dataenforce/__init__.py
@@ -15,7 +15,7 @@
 import inspect
 from functools import wraps
 import pandas as pd
-from typing import _TypingEmpty, _tp_cache, Generic, get_type_hints
+from typing import _TypingEmpty, _tp_cache, Generic, get_type_hints, NewType
 import numpy as np
 try:
     from typing import GenericMeta # Python 3.6
@@ -58,9 +58,12 @@ def _get_columns_dtypes(p):
         columns.add(p)
     elif isinstance(p, slice):
         columns.add(p.start)
-        if not inspect.isclass(p.stop):
-            raise TypeError("Column type hints must be classes, error with %s" % repr(p.stop))
-        dtypes[p.start] = p.stop
+        stop_type = p.stop
+        if isinstance(stop_type, NewType):
+            stop_type = stop_type.__supertype__
+        if not inspect.isclass(stop_type):
+            raise TypeError("Column type hints must be classes or of type NewType, error with %s" % repr(stop_type))
+        dtypes[p.start] = stop_type
     elif isinstance(p, (list, set)):
         for el in p:
             subcolumns, subdtypes = _get_columns_dtypes(el)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -83,6 +83,24 @@ def test_validate_other_types():
 
     process(df, 3)
 
+def test_validate_newtype():
+    from typing import NewType
+
+    UserId = NewType('UserId', int)
+
+    df = pd.DataFrame(dict(a=[UserId(1), UserId(2), UserId(3)], b=["a","b","c"]))
+    df2 = pd.DataFrame(dict(a=["1","2","3"], b=["a","b","c"]))
+
+    @validate
+    def process(data: Dataset["a": UserId, "b": object]):
+        pass
+
+    process(df)
+
+    with pytest.raises(TypeError):
+        process(df2)
+     
+
 def test_return_type():
     df = pd.DataFrame(dict(a=[1,2,3]))
 


### PR DESCRIPTION
A NewType definition will fail the `inspect.isclass` check. Retrieving and using the `__supertype__` will potentially fix this.

Example.
```python
from typing import NewType, Dict
UserId = NewType("UserId", int)

DUserDataset = Dataset["user": UserId, "properties": Dict[str, str]]
```