### PR TITLE
Allow the use of dict syntax

### DIFF
--- a/dataenforce/__init__.py
+++ b/dataenforce/__init__.py
@@ -61,6 +61,12 @@ def _get_columns_dtypes(p):
         if not inspect.isclass(p.stop):
             raise TypeError("Column type hints must be classes, error with %s" % repr(p.stop))
         dtypes[p.start] = p.stop
+    elif isinstance(p, dict):
+        for key, value in p.items():
+            columns.add(key)
+            if not inspect.isclass(value):
+                raise TypeError("Column type hints must be classes, error with %s" % repr(value))
+            dtypes[key] = value
     elif isinstance(p, (list, set)):
         for el in p:
             subcolumns, subdtypes = _get_columns_dtypes(el)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -44,6 +44,13 @@ def test_nested():
     assert DNameLocEtc.dtypes == {'id': int, 'name': object, "longitude": float, "latitude": float, "description": object}
     assert DNameLocEtc.only_specified == False
 
+def test_dict():
+    DName = Dataset[{"id": int, "name": object}]
+
+    assert DName.columns == {"id", "name"}
+    assert DName.dtypes == {"id": int, "name": object}
+    assert DName.only_specified == True
+
 def test_init():
     with pytest.raises(TypeError):
         Dataset()


### PR DESCRIPTION
Hi Cedric,

While working with dataenforce and MyPy, I noticed that the recommended syntax (`DataSet["id":float,"name":object]`) causes mypy to complain with the following error:

`error: Slice index must be an integer or None`

As a result, I added a similar syntax using dicts: `Dataset[{"id":float,"name":object}]`. Note that the order is not guaranteed with dictionaries as far as I know so an alternative syntax could be to use tuples instead:

`Dataset[("id",float), ("name",object)]`